### PR TITLE
Solve  web3j.ethLogFlowable is invalid

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
@@ -51,8 +51,11 @@ public class EthFilter extends Filter<EthFilter> {
         return toBlock;
     }
 
-    public List<String> getAddress() {
-        return address;
+    public String getAddress() {
+        if (address != null && address.size() == 1) {
+            return address.get(0);
+        }
+        return address.toString();
     }
 
     @Override


### PR DESCRIPTION
Solve  web3j.ethLogFlowable is invalid

If the address is only one, address is string ,not the array.Otherwise, no data will be subscribe.


